### PR TITLE
fix 🐛 Query params encode

### DIFF
--- a/lib/core/contentstackHTTPClient.js
+++ b/lib/core/contentstackHTTPClient.js
@@ -1,8 +1,8 @@
+import axios from 'axios'
 import clonedeep from 'lodash/cloneDeep'
 import Qs from 'qs'
-import axios from 'axios'
-import { isHost } from './Util'
 import { ConcurrencyQueue } from './concurrency-queue'
+import { isHost } from './Util'
 
 export default function contentstackHttpClient (options) {
   const defaultConfig = {
@@ -70,7 +70,7 @@ export default function contentstackHttpClient (options) {
       delete params.query
       var qs = Qs.stringify(params, { arrayFormat: 'brackets' })
       if (query) {
-        qs = qs + `&query=${encodeURI(JSON.stringify(query))}`
+        qs = qs + `&query=${encodeURIComponent(JSON.stringify(query))}`
       }
       params.query = query
       return qs


### PR DESCRIPTION
This PR solves #40 

Use encodeURIComponent instead of encodeURI. This is the same behaviour as the delivery SDK: https://github.com/contentstack/contentstack-javascript/blob/master/src/core/lib/request.js#L26