### PR TITLE
fix: incorrect bulk publish details object type

### DIFF
--- a/lib/stack/bulkOperation/index.js
+++ b/lib/stack/bulkOperation/index.js
@@ -50,7 +50,7 @@ export function BulkOperation (http, data = {}) {
    * {
    * environments:["{{env_uid}}","{{env_uid}}"],
    * locales:["en-us"],
-   * items:[
+   * entries:[
    * {
    *   _content_type_uid: '{{content_type_uid}}',
    *   uid: '{{entry_uid}}'
@@ -138,7 +138,7 @@ export function BulkOperation (http, data = {}) {
    * {
    * environments:["{{env_uid}}","{{env_uid}}"],
    * locales:["en-us"],
-   * items:[
+   * entries:[
    * {
    *   _content_type_uid: '{{content_type_uid}}',
    *   uid: '{{entry_uid}}'

--- a/types/stack/bulkOperation/index.d.ts
+++ b/types/stack/bulkOperation/index.d.ts
@@ -17,7 +17,7 @@ export interface BulkOperationConfig {
 }
 
 export interface PublishItems extends PublishDetails {
-    items: Array<BulkOperationItem>
+    entries: Array<BulkOperationItem>
 }
 
 export interface BulkOperationItem {


### PR DESCRIPTION
**Bug Fix**:
There is a bug in SDK in bulk operations because ContentStack api for all of them expects an "entries" property instead of "items":

You can refer to the [documentation](https://www.contentstack.com/docs/developers/apis/content-management-api/#bulk-publish-operation)