### PR TITLE
fix: incorrect ContentstackCollection items type

### DIFF
--- a/types/contentstackCollection.d.ts
+++ b/types/contentstackCollection.d.ts
@@ -3,7 +3,7 @@ export interface Response {
 }
 
 export interface ContentstackCollection<T> extends Response {
-    items: [T]
+    items: T[]
     count: number
 }
 


### PR DESCRIPTION
**Bug Fix**:
ContentstackCollection "items" field has a type [T] which is an array of single item but it should be a normal array T[] of 0 or more items.