### PR TITLE
fix: exclude stackHeaders from entry data assignment

### DIFF
--- a/lib/stack/contentType/entry/index.js
+++ b/lib/stack/contentType/entry/index.js
@@ -29,7 +29,8 @@ export function Entry (http, data) {
     if (this.apiVersion && !this.stackHeaders.api_version) {
       this.stackHeaders.api_version = this.apiVersion;
     }
-    Object.assign(this, cloneDeep(data.entry))
+    const { stackHeaders, ...entryData } = data.entry;
+    Object.assign(this, cloneDeep(entryData));
     this.urlPath = `/content_types/${this.content_type_uid}/entries/${this.uid}`
 
     /**


### PR DESCRIPTION
Previously, if an entry contained stackHeaders, it would overwrite the existing stack headers. If tokens were updated in the meantime, this could result in an authorization error.