### PR TITLE
chore: upgrade axios to 1.12.0 to address CVE-2025-58754

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "assert": "^2.1.0",
-        "axios": "^1.11.0",
+        "axios": "^1.12.0",
         "buffer": "^6.0.3",
         "form-data": "^4.0.4",
         "husky": "^9.1.7",
@@ -3747,7 +3747,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "license": "MIT",
   "dependencies": {
     "assert": "^2.1.0",
-    "axios": "^1.11.0",
+    "axios": "^1.12.0",
     "buffer": "^6.0.3",
     "form-data": "^4.0.4",
     "husky": "^9.1.7",


### PR DESCRIPTION
This PR addresses a high-level security vulnerability reported for axios for versions 1.11.0 and below: [CVE-2025-58754](https://www.cve.org/CVERecord?id=CVE-2025-58754).

Axios has been upgraded to use a minimum version of 1.12.0, which patches the vulnerability.