### PR TITLE
Fix taxonomy empty items status assertion

### DIFF
--- a/test/sanity-check/api/taxonomy-test.js
+++ b/test/sanity-check/api/taxonomy-test.js
@@ -308,7 +308,7 @@ describe('Taxonomy API Tests', () => {
         await stack.taxonomy().publish({ locales: ['en-us'], environments: ['development'], items: [] })
         // Some environments may accept empty arrays, just check it returns something
       } catch (e) {
-        expect(e.status).to.be.oneOf([400, 422])
+        expect(e.status).to.be.oneOf([400, 412, 422])
       }
     })
 
@@ -367,7 +367,7 @@ describe('Taxonomy API Tests', () => {
       try {
         await stack.taxonomy().unpublish({ locales: ['en-us'], environments: ['development'], items: [] })
       } catch (e) {
-        expect(e.status).to.be.oneOf([400, 422])
+        expect(e.status).to.be.oneOf([400, 412, 422])
       }
     })
   })


### PR DESCRIPTION
## Summary
- Accept the current CMA 412 response for taxonomy publish/unpublish empty-items validation.
- Keep existing accepted 400 and 422 statuses for older validation behavior.

## Validation
- ./node_modules/.bin/eslint test/sanity-check/api/taxonomy-test.js
- git diff --check