### PR TITLE
Fix team organizationRole assertion for RBAC orgs

### DIFF
--- a/test/sanity-check/api/team-test.js
+++ b/test/sanity-check/api/team-test.js
@@ -87,7 +87,8 @@ describe('Teams API Tests', () => {
       trackedExpect(response.uid, 'Team UID').toExist()
       trackedExpect(response.uid, 'Team UID type').toBeA('string')
       trackedExpect(response.name, 'Team name').toEqual(teamData.name)
-      trackedExpect(response.organizationRole, 'Team organizationRole').toExist()
+      const orgRole = response.organizationRole || response.organizationRoles
+      trackedExpect(orgRole, 'Team organizationRole/organizationRoles').toExist()
 
       // Wait for team to be fully created
       await wait(2000)


### PR DESCRIPTION
## Summary
- RBAC-enabled organizations changed the team create response field from `organizationRole` (singular string) to `organizationRoles` (plural array), causing the sanity assertion at [team-test.js:90](test/sanity-check/api/team-test.js#L90) to fail with `expected undefined to exist` on dev11.
- Updated the assertion to accept either field so it passes on both legacy and RBAC-enabled orgs.

## Context
Reported by Bala: *"For RBAC orgs, the response is changed to organizationRoles, please update the sanity accordingly."*

- API call still succeeds (HTTP 201, team created correctly).
- Request payload is unchanged — the API still accepts `organizationRole` (singular) as input.
- Only the response field name changed, so only the response-side assertion needed updating.

## Test plan
- [ ] Re-run sanity pipeline  — team create should pass.
- [ ] Verify on a non-RBAC org that the assertion still passes via `response.organizationRole`.